### PR TITLE
Use current value as default value, instead of 0

### DIFF
--- a/src/Controls/ofxSimpleGuiButton.cpp
+++ b/src/Controls/ofxSimpleGuiButton.cpp
@@ -15,7 +15,7 @@ void ofxSimpleGuiButton::setup() {
 
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiButton::loadFromXML(ofxXmlSettings &XML) {
-	setValue(XML.getValue(controlType + "_" + key + ":value", 0));
+	setValue(XML.getValue(controlType + "_" + key + ":value", getValue()));
 }
 
 void ofxSimpleGuiButton::saveToXML(ofxXmlSettings &XML) {

--- a/src/Controls/ofxSimpleGuiColorPicker.cpp
+++ b/src/Controls/ofxSimpleGuiColorPicker.cpp
@@ -29,7 +29,7 @@ void ofxSimpleGuiColorPicker::setup() {
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiColorPicker::loadFromXML(ofxXmlSettings &XML) {
 	for(int i=0; i<4; i++) {
-		setValue(XML.getValue(controlType + "_" + key + ":values_" + ofToString(i), 0.0f), i);
+		setValue(XML.getValue(controlType + "_" + key + ":values_" + ofToString(i), getValue(i)), i);
 	}
 }
 

--- a/src/Controls/ofxSimpleGuiComboBox.cpp
+++ b/src/Controls/ofxSimpleGuiComboBox.cpp
@@ -87,7 +87,7 @@ void ofxSimpleGuiComboBox::setup() {
 
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiComboBox::loadFromXML(ofxXmlSettings &XML) {
-	setValue(XML.getValue(controlType + "_" + key + ":value", 0));
+	setValue(XML.getValue(controlType + "_" + key + ":value", getValue()));
 }
 
 void ofxSimpleGuiComboBox::saveToXML(ofxXmlSettings &XML) {

--- a/src/Controls/ofxSimpleGuiQuadWarp.cpp
+++ b/src/Controls/ofxSimpleGuiQuadWarp.cpp
@@ -27,8 +27,8 @@ void ofxSimpleGuiQuadWarp::setup() {
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiQuadWarp::loadFromXML(ofxXmlSettings &XML) {
 	for(int i=0; i<4; i++) {
-		pts[i].x = XML.getValue(controlType + "_" + key + ":values_" + ofToString(i) + "_x", 0.0f);
-		pts[i].y = XML.getValue(controlType + "_" + key + ":values_" + ofToString(i) + "_y", 0.0f);
+		pts[i].x = XML.getValue(controlType + "_" + key + ":values_" + ofToString(i) + "_x", pts[i].x);
+		pts[i].y = XML.getValue(controlType + "_" + key + ":values_" + ofToString(i) + "_y", pts[i].y);
 	}
 }
 

--- a/src/Controls/ofxSimpleGuiSlider2d.cpp
+++ b/src/Controls/ofxSimpleGuiSlider2d.cpp
@@ -18,7 +18,7 @@ void ofxSimpleGuiSlider2d::setup() {
 
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiSlider2d::loadFromXML(ofxXmlSettings &XML) {
-	value->set(XML.getValue(controlType + "_" + key + ":valueX", 0.0f), XML.getValue(controlType + "_" + key + ":valueY", 0.0f));
+	value->set(XML.getValue(controlType + "_" + key + ":valueX", value->x), XML.getValue(controlType + "_" + key + ":valueY", value->y));
 }
 
 

--- a/src/Controls/ofxSimpleGuiSliderBase.h
+++ b/src/Controls/ofxSimpleGuiSliderBase.h
@@ -50,7 +50,7 @@ public:
 
 #ifndef OFXMSAGUI_DONT_USE_XML
 	void loadFromXML(ofxXmlSettings &XML) {
-		setValue((Type)XML.getValue(controlType + "_" + key + ":value", 0.0f));
+		setValue((Type)XML.getValue(controlType + "_" + key + ":value", getValue()));
 	}
     
 	void saveToXML(ofxXmlSettings &XML) {

--- a/src/Controls/ofxSimpleGuiTitle.cpp
+++ b/src/Controls/ofxSimpleGuiTitle.cpp
@@ -21,7 +21,7 @@ void ofxSimpleGuiTitle::setup() {
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiTitle::loadFromXML(ofxXmlSettings &XML) {
 	if(!value) return;
-	setValue(XML.getValue(controlType + "_" + key + ":value", 0));
+	setValue(XML.getValue(controlType + "_" + key + ":value", getValue()));
 }
 
 void ofxSimpleGuiTitle::saveToXML(ofxXmlSettings &XML) {

--- a/src/Controls/ofxSimpleGuiToggle.cpp
+++ b/src/Controls/ofxSimpleGuiToggle.cpp
@@ -21,7 +21,7 @@ void ofxSimpleGuiToggle::setup() {
 
 #ifndef OFXMSAGUI_DONT_USE_XML
 void ofxSimpleGuiToggle::loadFromXML(ofxXmlSettings &XML) {
-	setValue(XML.getValue(controlType + "_" + key + ":value", 0));
+	setValue(XML.getValue(controlType + "_" + key + ":value", getValue()));
 }
 
 void ofxSimpleGuiToggle::saveToXML(ofxXmlSettings &XML) {


### PR DESCRIPTION
When we add a new control, the XML does not yet contain a value.
Current version sets the value to 0 by default, but this is not always appropriate.
This patch uses current variable value as default for the control, so it is easy to provide a good default value from the code, just by initializing the variable before loading the xml.
