### PR TITLE
save/load presets

### DIFF
--- a/src/ofxSimpleGuiPage.cpp
+++ b/src/ofxSimpleGuiPage.cpp
@@ -19,14 +19,15 @@ ofxSimpleGuiPage &ofxSimpleGuiPage::setXMLName(string s) {
 }
 
 
-void ofxSimpleGuiPage::loadFromXML() {
-	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiPage::loadFromXML: " + xmlFilename);
+void ofxSimpleGuiPage::loadFromXML(string xmlFilepath) {
+    string fullPath = xmlFilepath + xmlFilename;
+	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiPage::loadFromXML: " + fullPath);
 #ifndef OFXMSAGUI_DONT_USE_XML
 	
 	if(xmlFilename.compare("") == 0) return;
 
-	if(XML.loadFile(xmlFilename) == false) {
-		ofLog(OF_LOG_ERROR, "Error loading xmlFilename: " + xmlFilename);
+	if(XML.loadFile(fullPath) == false) {
+		ofLog(OF_LOG_ERROR, "Error loading xmlFilename: " + fullPath);
 		return;
 	}
 	
@@ -38,8 +39,7 @@ void ofxSimpleGuiPage::loadFromXML() {
 #endif    
 }
 
-
-void ofxSimpleGuiPage::saveToXML() {
+void ofxSimpleGuiPage::saveToXML(string xmlFilepath) {
 	if(controls.size() <= 1 || xmlFilename.compare("") == 0) return;	// if it has no controls (title counts as one control)
 	
 #ifndef OFXMSAGUI_DONT_USE_XML
@@ -52,9 +52,10 @@ void ofxSimpleGuiPage::saveToXML() {
 	}
 	XML.popTag();
 	
-	XML.saveFile(xmlFilename);
+    string fullPath = xmlFilepath + xmlFilename;
+	XML.saveFile(fullPath);
 	//	if(doSaveBackup) 
-	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiPage::saveToXML: " + xmlFilename + " " + ofToString(controls.size(), 0) + " items");
+	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiPage::saveToXML: " + fullPath + " " + ofToString(controls.size(), 0) + " items");
 #endif    
 }
 

--- a/src/ofxSimpleGuiPage.h
+++ b/src/ofxSimpleGuiPage.h
@@ -10,8 +10,8 @@ public:
 	void						draw(float x, float y, bool alignRight);
 	
 	ofxSimpleGuiPage&			setXMLName(string xmlFilename);
-	void						loadFromXML();
-	void						saveToXML();	
+	void						loadFromXML(string xmlFilepath = "");
+    void                        saveToXML(string xmlFilepath = "");
 	
 	
 	ofxSimpleGuiControl			&addControl(ofxSimpleGuiControl& control);

--- a/src/ofxSimpleGuiToo.cpp
+++ b/src/ofxSimpleGuiToo.cpp
@@ -13,6 +13,7 @@ void ofxSimpleGuiToo::setup() {
 	config			= &defaultSimpleGuiConfig;
 
 	doSave			= false;
+    savePreset      = false;
 	changePage		= false;
 	titleButton		= NULL;
 
@@ -22,6 +23,8 @@ void ofxSimpleGuiToo::setup() {
 	titleButton = &headerPage->addButton("title", changePage);
 	headerPage->addToggle("Auto Save", doAutoSave);
 	headerPage->addButton("Save Settings", doSave);
+    headerPage->addButton("Save Preset", savePreset);
+    headerPage->addButton("Load Preset", loadPreset);
 	headerPage->addFPSCounter();
 
 	addPage();
@@ -105,22 +108,22 @@ void ofxSimpleGuiToo::setAutoSave(bool b) {
 }
 
 
-void ofxSimpleGuiToo::loadFromXML() {
+void ofxSimpleGuiToo::loadFromXML(string path) {
 	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiToo::loadFromXML");// + file);
 
 	for(int i=1; i < pages.size(); i++) {
-		pages[i]->loadFromXML();
+		pages[i]->loadFromXML(path);
 	}
 
 	setPage(1);
 }
 
 
-void ofxSimpleGuiToo::saveToXML() {
+void ofxSimpleGuiToo::saveToXML(string path) {
 	doSave = false;
 
 	for(int i=1; i < pages.size(); i++) {
-		pages[i]->saveToXML();
+		pages[i]->saveToXML(path);
 	}
 
 	ofLog(OF_LOG_VERBOSE, "ofxSimpleGuiToo::saveToXML");
@@ -340,6 +343,27 @@ void ofxSimpleGuiToo::update(ofEventArgs &e) {
 //	if(doSaveBackup) doSave = true;
 
 	if(doSave) saveToXML();
+    
+    if(savePreset) {
+        savePreset = false;
+        ofFileDialogResult saveResult = ofSystemSaveDialog("my-preset", "Save preset");
+        if (saveResult.bSuccess) {
+            ofDisableDataPath();
+            ofDirectory::createDirectory(saveResult.getPath(), false);
+            saveToXML(saveResult.getPath() + "/");
+            ofEnableDataPath();
+        }
+    }
+    
+    if(loadPreset) {
+        loadPreset = false;
+        ofFileDialogResult loadResult = ofSystemLoadDialog("Load preset", true);
+        if (loadResult.bSuccess) {
+            ofDisableDataPath();
+            loadFromXML(loadResult.getPath() + "/");
+            ofEnableDataPath();
+        }
+    }
 }
 //void ofxSimpleGuiToo::draw(ofEventArgs &e) {
 //void ofxSimpleGuiToo::exit(ofEventArgs &e) {

--- a/src/ofxSimpleGuiToo.h
+++ b/src/ofxSimpleGuiToo.h
@@ -54,8 +54,8 @@ public:
 	void						setup();
 	
 	
-	void						loadFromXML();
-	void						saveToXML();	
+	void						loadFromXML(string path = "");
+	void						saveToXML(string path = "");
 	void						setAutoSave(bool b);
 	void						setAlignRight(bool b);
 	void						setDefaultKeys(bool b);
@@ -114,6 +114,8 @@ protected:
 	bool							alignRight;
 	bool							doDefaultKeys;
 	bool							doSave;//, doSaveBackup;
+    bool                            savePreset;
+    bool                            loadPreset;
 	bool							changePage;
 	int								forceHeight;
 	int								currentPageIndex;			// 1 based index of page (0 is for global controls)


### PR DESCRIPTION
Adds 2 buttons to the header:
- Save Preset (saves all current settings to a user specified directory)
- Load Preset (loads all settings from a user selected directory)