### PR TITLE
Fix error: ‘isMousePressed’ was not declared in this scope

### DIFF
--- a/src/ofxSimpleGuiControl.cpp
+++ b/src/ofxSimpleGuiControl.cpp
@@ -65,7 +65,7 @@ ofxSimpleGuiControl &ofxSimpleGuiControl::setTextBGColor(bool clickable) {
 }
 
 ofxSimpleGuiControl &ofxSimpleGuiControl::setFullColor(bool forceActive) {
-	if(isMousePressed() || forceActive) ofSetHexColor(config->fullActiveColor);
+	if(isMouseDown() || forceActive) ofSetHexColor(config->fullActiveColor);
 	else if(isMouseOver()) ofSetHexColor(config->fullOverColor);
 	else ofSetHexColor(config->fullColor);
 	return *this;


### PR DESCRIPTION
This PR fixes the issue #3 https://github.com/memo/ofxSimpleGuiToo/issues/3